### PR TITLE
Infrastructure for API-level configuration

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,17 @@
+"""Read and expose keys."""
+from config.models import Config
+from pathlib import Path
+import yaml
+
+
+config_path = (Path(__file__).parent.parent / "config.yaml").absolute()
+
+if not config_path.exists():
+    raise FileNotFoundError("config.yaml file not found.")
+
+with open(str(config_path), "r", encoding="utf-8") as f:
+    RAW_CONFIG = yaml.safe_load(f)
+
+
+# Validate the keys and expose KEYS
+CONFIG = Config(**RAW_CONFIG)

--- a/config/models.py
+++ b/config/models.py
@@ -1,0 +1,15 @@
+"""Models for the keys."""
+from pydantic import BaseModel
+
+
+class GeneralConfig(BaseModel):
+    """
+    Model for general configuration.
+    """
+
+
+class Config(BaseModel):
+    """
+    Model for all configuration.
+    """
+    General: GeneralConfig


### PR DESCRIPTION
Public [config.yaml](config.yaml) file with an interface `config` similar to `keys`.

```python
from config import CONFIG
```