### PR TITLE
Separate QA and production deployment pipelines

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -48,11 +48,11 @@ jobs:
         id: deploy
         uses: 'google-github-actions/deploy-cloudrun@v2'
         with:
-          service: 'CONTAINER_NAME'
+          service: 'CONTAINER_NAME-qa'
           image: gcr.io/GCP_PROJECT/CONTAINER_NAME:pr-preview-${{ github.event.number }}
           tag: pr-preview-${{ github.event.number }}
+          region: us-central1
           flags: '--min-instances=0 --allow-unauthenticated'
-          no_traffic: true
 
       - name: Comment deployment
         uses: thollander/actions-comment-pull-request@v3

--- a/.github/workflows/google-cloud.yaml
+++ b/.github/workflows/google-cloud.yaml
@@ -58,5 +58,8 @@ jobs:
         with:
           service: CONTAINER_NAME
           image: gcr.io/GCP_PROJECT/CONTAINER_NAME
+          region: us-central1
           flags: '--min-instances=0 --allow-unauthenticated'
-          no_traffic: false
+
+      - name: Update traffic to latest revision
+        run: gcloud run services update-traffic CONTAINER_NAME --to-latest --region us-central1


### PR DESCRIPTION
No need to specify `no_traffic`. And, manually update traffic to latest revision as there's no risk of crossover anymore. 